### PR TITLE
Add Other resources section

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,15 @@
             </li>
 
         </ul>
+<h2>Other</h2>
+        <ul class="section-list">
+            <li class="section-item">
+                <a href="other/README.html">
+                    <strong>Other — дополнительные материалы</strong>
+                </a>
+            </li>
+
+        </ul>
 </div>
 </body>
 </html>

--- a/other/README.html
+++ b/other/README.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Other — дополнительные материалы</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <div class="container">
+<h3>Other — дополнительные материалы</h3>
+        <ul class="section-list">
+            <li class="section-item">
+                <a href="sites.html">
+                    <strong>1. Веб-сайты и онлайн-материалы</strong>
+                </a>
+            </li>
+            <li class="section-item">
+                <a href="apps.html">
+                    <strong>2. Приложения</strong>
+                </a>
+            </li>
+            <li class="section-item">
+                <a href="youtube.html">
+                    <strong>3. YouTube-каналы и видео/плейлисты</strong>
+                </a>
+            </li>
+        </ul>
+        <div class="back-link">
+            <a href="../index.html">Back</a>
+        </div>
+
+    </div>
+</body>
+</html>

--- a/other/apps.html
+++ b/other/apps.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Приложения</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <div class="container">
+<p>1. <strong>BoldVoice App</strong>: Бесплатная оценка и 7 дней уроков с видео от голливудских коучей. Ссылка: <a href="https://www.boldvoice.com/">boldvoice.com</a>.</p>
+<p>2. <strong>Speechling App</strong>: Бесплатная запись и обратная связь от коучей, тысячи фраз для практики. Ссылка: <a href="https://speechling.com/">speechling.com</a>.</p>
+<p>3. <strong>Gliglish App</strong>: Бесплатно 10 минут в день разговоров с AI и фидбеком по произношению. Ссылка: <a href="https://gliglish.com/">gliglish.com</a>.</p>
+<p>4. <strong>HelloTalk</strong>: Бесплатный обмен языками — чат и голосовые комнаты с носителями. Получайте корректировки произношения в реальном времени. Ссылка: <a href="https://hellotalk.com">hellotalk.com</a>.</p>
+    </div>
+</body>
+</html>

--- a/other/sites.html
+++ b/other/sites.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Веб-сайты и онлайн-материалы</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <div class="container">
+<p>1. <strong>SpeechActive</strong>: Бесплатный стартовый курс по произношению (5 email-уроков) с фокусом на трудности русских. Инструмент для записи и сравнения звуков. Ссылки: <a href="https://www.speechactive.com/english-pronunciation-accent-reduction-russian/">курс</a>, <a href="https://www.speechactive.com/listen-english-vowels-and-consonant-sounds/">рекордер</a>.</p>
+<p>2. <strong>BoldVoice</strong>: Блог с советами по типичным трудностям русских. Бесплатная оценка акцента и 7-дневный trial в приложении. Ссылка: <a href="https://www.boldvoice.com/blog/english-pronunciation-russian-speakers">blog</a>, <a href="https://www.boldvoice.com/">оценка</a>.</p>
+<p>3. <strong>YouGlish</strong>: Бесплатный инструмент для прослушивания реального произношения слов в видео. Помогает практиковать интонацию и ритм. Ссылка: <a href="https://youglish.com/">youglish.com</a>.</p>
+<p>4. <strong>Speechling</strong>: Бесплатная практика с записью предложений и обратной связью от коучей, тысячи фраз с носителями. Ссылка: <a href="https://speechling.com/">speechling.com</a>.</p>
+<p>5. <strong>Gliglish</strong>: Бесплатные 10 минут в день разговоров с AI и обратной связью по произношению. Поддерживает русский как исходный язык. Ссылка: <a href="https://gliglish.com/">gliglish.com</a>.</p>
+<p><em>Сайты для прослушивания акцентов:</em></p>
+<p>6. <strong>International Dialects of English Archive</strong>: бесплатные записи носителей, чтение текстов. Ссылка: <a href="http://www.dialectsarchive.com/">dialectsarchive.com</a>.</p>
+<p>7. <strong>Speech Accent Archive</strong>: фразы в разных акцентах, включая non-native. Ссылка: <a href="http://accent.gmu.edu/">accent.gmu.edu</a>.</p>
+<p>8. <strong>LibriVox</strong>: бесплатные аудиокниги с разными акцентами для практики. Ссылка: <a href="https://librivox.org/">librivox.org</a>.</p>
+    </div>
+</body>
+</html>

--- a/other/youtube.html
+++ b/other/youtube.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YouTube-каналы и видео</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <div class="container">
+<p>1. <strong>English Pronunciation Course For Russian Speakers</strong> — плейлист из 11 видео. <a href="https://www.youtube.com/playlist?list=PLi2YtixXXV8wtN5LQDInqhqiK76v0eh3w">ссылка</a>.</p>
+<p>2. <strong>Free English Help for Ukrainian and Russian Speakers</strong> — уроки по произношению для славянских носителей. <a href="https://www.youtube.com/watch?v=QkUAloBbByM">видео</a>.</p>
+<p>3. <strong>American Accent Training for RUSSIAN Speakers</strong> — советы по американскому акценту. <a href="https://www.youtube.com/watch?v=yKRiCmGIMVw">видео</a>.</p>
+<p>4. <strong>10 pronunciation mistakes RUSSIAN SPEAKERS make</strong> — анализ типичных ошибок и упражнения. <a href="https://www.youtube.com/watch?v=ZPPBQcz-ZPk">видео</a>.</p>
+<p>5. <strong>How to Speak English - Pronunciation for Russian Speakers</strong> — урок по естественному произношению. <a href="https://www.youtube.com/watch?v=g3L21HDRt5A">видео</a>.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add link to new Other section on the homepage
- provide Other landing page with subpages
- include resource lists for sites, apps and YouTube playlists

## Testing
- `python -m py_compile apply_template.py`


------
https://chatgpt.com/codex/tasks/task_e_68885b0ff8948325a8ffa9dfd28c8d15